### PR TITLE
fix: override `upload_max_filesize` and set it to `64M`

### DIFF
--- a/custom.ini
+++ b/custom.ini
@@ -1,0 +1,1 @@
+upload_max_filesize = 64M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       WORDPRESS_DEBUG: 1
     volumes:
       - wordpress_data:/var/www/html
-      - .:/var/www/html/wp-content/plugins/screenly-cast
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   # Modern development environment
   wordpress:
-    image: wordpress:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.wordpress
     ports:
       - "8000:80"
     environment:

--- a/docker/Dockerfile.wordpress
+++ b/docker/Dockerfile.wordpress
@@ -1,0 +1,6 @@
+FROM wordpress:latest
+
+RUN apt-get update -y
+
+COPY custom.ini $PHP_INI_DIR/conf.d/
+WORKDIR /var/www/html


### PR DESCRIPTION
### Description

* Creates a custom config file called `custom.ini` which includes an override for `upload_max_filesize`
* Created a new `Dockerfile` for the wordpress service