### PR TITLE
fix: `screenly-cast` is not mounted properly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       WORDPRESS_DEBUG: 1
     volumes:
       - wordpress_data:/var/www/html
+      - ./screenly-cast:/var/www/html/wp-content/plugins/screenly-cast
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
### Description

* The `./screenly-cast` directory (instead of the project root) should be mounted to `/var/www/html/wp-content/plugins/screenly-cast`.
* This PR fixes issues with the development environment. With the changes applied, any changes that are made to the code will be reflected in the plugin.