### PR TITLE
fix: update handling of query parameters and theming

### DIFF
--- a/screenly-cast/inc/Core.php
+++ b/screenly-cast/inc/Core.php
@@ -191,11 +191,17 @@ class Core {
 	 */
 	public function deactivate(): void {
 		if ( get_stylesheet() === 'screenly-cast' ) {
-			$default_theme = get_option( 'theme_switched' ) ? get_option( 'theme_switched' ) : 'twentytwentyfour';
-			switch_theme( $default_theme );
+			$previous_theme = get_option('screenly_previous_theme', 'twentytwentyfive');
+			switch_theme($previous_theme);
+
+			if (!is_admin()) {
+				wp_redirect(remove_query_arg('srly'));
+				exit;
+			}
 		}
 
-		delete_option( 'screenly_cast_enabled' );
+		delete_option('screenly_previous_theme');
+		delete_option('screenly_cast_enabled');
 		flush_rewrite_rules();
 	}
 
@@ -233,14 +239,8 @@ class Core {
 					exit;
 				}
 				$query->set( 'posts_per_page', 1 );
-			} else {
-				$previous_theme = get_option('screenly_previous_theme', 'twentytwentyfive');
-
-				if (get_stylesheet() === 'screenly-cast') {
-					switch_theme($previous_theme);
-					wp_redirect(remove_query_arg('srly'));
-					exit;
-				}
+			} else if (get_stylesheet() === 'screenly-cast') {
+				$this->deactivate();
 			}
 		}
 	}

--- a/screenly-cast/inc/Core.php
+++ b/screenly-cast/inc/Core.php
@@ -191,17 +191,17 @@ class Core {
 	 */
 	public function deactivate(): void {
 		if ( get_stylesheet() === 'screenly-cast' ) {
-			$previous_theme = get_option('screenly_previous_theme', 'twentytwentyfive');
-			switch_theme($previous_theme);
+			$previous_theme = get_option( 'screenly_previous_theme', 'twentytwentyfive' );
+			switch_theme( $previous_theme );
 
-			if (!is_admin()) {
-				wp_redirect(remove_query_arg('srly'));
+			if ( ! is_admin() ) {
+				wp_redirect( remove_query_arg( 'srly' ) );
 				exit;
 			}
 		}
 
-		delete_option('screenly_previous_theme');
-		delete_option('screenly_cast_enabled');
+		delete_option( 'screenly_previous_theme' );
+		delete_option( 'screenly_cast_enabled' );
 		flush_rewrite_rules();
 	}
 

--- a/screenly-cast/inc/Core.php
+++ b/screenly-cast/inc/Core.php
@@ -224,13 +224,23 @@ class Core {
 	 */
 	public function parse_query( \WP_Query $query ): void {
 		if ( ! $query->is_admin() && $query->is_main_query() ) {
-			$srly = $query->get( 'srly' );
-
 			if ( array_key_exists( 'srly', $query->query_vars ) ) {
+				$current_theme = get_stylesheet();
+				if ($current_theme !== 'screenly-cast') {
+					update_option('screenly_previous_theme', $current_theme);
+					$this->theme_manager->activate( 'screenly-cast' );
+					wp_redirect(add_query_arg('srly', ''));
+					exit;
+				}
 				$query->set( 'posts_per_page', 1 );
-				$this->theme_manager->activate( 'screenly-cast' );
 			} else {
-				$this->deactivate();
+				$previous_theme = get_option('screenly_previous_theme', 'twentytwentyfive');
+
+				if (get_stylesheet() === 'screenly-cast') {
+					switch_theme($previous_theme);
+					wp_redirect(remove_query_arg('srly'));
+					exit;
+				}
 			}
 		}
 	}

--- a/screenly-cast/inc/Core.php
+++ b/screenly-cast/inc/Core.php
@@ -223,11 +223,14 @@ class Core {
 	 * @param \WP_Query $query The WordPress query object.
 	 */
 	public function parse_query( \WP_Query $query ): void {
-		if ( ! $query->is_admin && $query->is_main_query ) {
+		if ( ! $query->is_admin() && $query->is_main_query() ) {
 			$srly = $query->get( 'srly' );
-			if ( $srly ) {
-				$query->set( 'post_type', 'screenly_cast' );
+
+			if ( array_key_exists( 'srly', $query->query_vars ) ) {
 				$query->set( 'posts_per_page', 1 );
+				$this->theme_manager->activate( 'screenly-cast' );
+			} else {
+				$this->deactivate();
 			}
 		}
 	}

--- a/screenly-cast/inc/Core.php
+++ b/screenly-cast/inc/Core.php
@@ -232,14 +232,14 @@ class Core {
 		if ( ! $query->is_admin() && $query->is_main_query() ) {
 			if ( array_key_exists( 'srly', $query->query_vars ) ) {
 				$current_theme = get_stylesheet();
-				if ($current_theme !== 'screenly-cast') {
-					update_option('screenly_previous_theme', $current_theme);
+				if ( 'screenly-cast' !== $current_theme ) {
+					update_option( 'screenly_previous_theme', $current_theme );
 					$this->theme_manager->activate( 'screenly-cast' );
-					wp_redirect(add_query_arg('srly', ''));
+					wp_redirect( add_query_arg( 'srly', '' ) );
 					exit;
 				}
 				$query->set( 'posts_per_page', 1 );
-			} else if (get_stylesheet() === 'screenly-cast') {
+			} else if ( 'screenly-cast' === get_stylesheet() ) {
 				$this->deactivate();
 			}
 		}

--- a/screenly-cast/inc/Plugin.php
+++ b/screenly-cast/inc/Plugin.php
@@ -90,7 +90,6 @@ class Plugin {
 		try {
 			$this->check_requirements();
 			$this->install_theme();
-			$this->activate_theme();
 			$this->settings->init();
 			$this->core->init();
 			$this->core->admin_init();

--- a/tests/test-integration.php
+++ b/tests/test-integration.php
@@ -29,7 +29,8 @@ class TestIntegration extends WP_UnitTestCase {
         try {
             $this->plugin->init();
             if (version_compare($wp_version, '6.2.4', '>=')) {
-                $this->assertEquals('screenly-cast', get_stylesheet());
+                $this->assertTrue(wp_get_theme('screenly-cast')->exists(), 'Screenly Cast theme should exist');
+                $this->assertEquals('twentytwentyfour', get_stylesheet());
             }
         } catch (\Exception $e) {
             if (version_compare($wp_version, '6.2.4', '>=')) {


### PR DESCRIPTION
### Description

* Regardless of whether the srly query parameter is specified or not, the `screenly-cast` theme is being applied.

### Changes

* Fixes call to `is_query()` and `is_main_query()`
* Updated the conditional statement so that the `screenly-cast` theme will only take effect if the `srly` query parameter is specified even if it doesn't have a set value