### PR TITLE
chore: bump Screenly Cast version to `1.0.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "screenly-cast-for-wordpress",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "screenly-cast-for-wordpress",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {
         "@wordpress/eslint-plugin": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screenly-cast-for-wordpress",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A WordPress plugin to enable easy and beautiful casting of pages, posts and image media on [Screenly](https://www.screenly.io) digital signage devices.",
   "main": "index.js",
   "directories": {

--- a/screenly-cast/readme.txt
+++ b/screenly-cast/readme.txt
@@ -3,7 +3,7 @@ Contributors: vpetersson
 Tags: digital signage, screenly
 Requires at least: 6.2.4
 Tested up to: 6.4.3
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 Requires PHP: 7.4
 License: GPLv2
 License URI: https://github.com/Screenly/Screenly-Cast-for-WordPress/blob/master/LICENSE
@@ -49,6 +49,11 @@ For support, feature requests, and bug reports, please visit our [GitHub Issues 
 2. The same page with Screenly Cast enabled.
 
 == Changelog ==
+
+= 1.0.5 =
+* Fix: Make failing unit tests pass
+* Fix: Update handling of the `?srly` query parameter
+* Fix: Screenly Cast theme not being applied when using the `srly` query parameter
 
 = 1.0.4 =
 * Fix: Move build artifacts to separate dist/ directory

--- a/screenly-cast/screenly-cast.php
+++ b/screenly-cast/screenly-cast.php
@@ -3,7 +3,7 @@
  * Plugin Name: Screenly Cast
  * Plugin URI: https://www.screenly.io
  * Description: A WordPress plugin to enable easy and beautiful casting of pages, posts and image media on Screenly digital signage devices.
- * Version: 1.0.4
+ * Version: 1.0.5
  * Requires at least: 6.2.4
  * Requires PHP: 7.4
  * Author: Screenly, Inc


### PR DESCRIPTION
### Description

Updated all references to the latest version from `1.0.4` to `1.0.5`.

### Changes Made

* Updated `package.json`, `package-lock.json`, `screenly-cast/readme.txt`, and `screenly-cast/screenly-cast.php` to use `1.0.5` as the latest version


### Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My code follows the project's coding standards
- [x] I have added/updated tests as needed
- [x] All tests pass locally