### PR TITLE
fix: enable the themes submenu in the admin site

### DIFF
--- a/screenly-cast/inc/Settings.php
+++ b/screenly-cast/inc/Settings.php
@@ -51,14 +51,6 @@ class Settings implements SettingsInterface {
 
 		// Add settings menu item.
 		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
-
-		// Remove default theme menu items.
-		add_action(
-			'admin_menu',
-			function (): void {
-				remove_submenu_page( 'themes.php', 'themes.php' );
-			}
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Description

* The Themes sub-menu in the admin site is hidden when the Screenly Cast plugin is enabled.

### Changes Made

* Removes the code that removes the themes sub-menu from the settings page.

### Testing Instructions

Run the following command:

```
cd /path/to/Screenly-Cast-for-WordPress
docker compose up -d --build
```

Open your browser and go to `http://localhost:8000/wp-admin`.

On the side-nav, hover to the **_Appearance_**, then click **_Themes_**.

### Screenshots

![image](https://github.com/user-attachments/assets/c5755d2a-eaf2-4c41-9370-5966273063db)

### Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My code follows the project's coding standards
- [x] I have added/updated tests as needed
- [x] All tests pass locally