### PR TITLE
chore(ci): add a step for creating a release and uploading files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,9 @@ jobs:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: screenly-cast
         BUILD_DIR: build/screenly-cast
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          dist/screenly-cast.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,6 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
+        prerelease: true
         files: |
           dist/screenly-cast.zip


### PR DESCRIPTION
### Description

* Creates a GitHub Actions workflow file that uploads the packaged plugin as an artifact
  * Uses [softprops/action-gh-release](https://github.com/softprops/action-gh-release?tab=readme-ov-file#-usage)
* With the `.zip` files being generated when a pull request is created or updated, anyone can just download them and use it for testing, for instance.

I tried using the same GitHub Action on my personal toy repo and it worked:

* **_Code Snippet_:** https://github.com/nicomiguelino/devtools/blob/8136eaa2da03d1061e59c65b57ef29708f28b47e/.github/workflows/build.yaml#L47-L53
* **_CI Run:_** https://github.com/nicomiguelino/devtools/actions/runs/13066483257/job/36459629311
* **_GitHub Release:_** https://github.com/nicomiguelino/devtools/releases/tag/v0.0.8

```yaml
      - name: Create Release
        if: startsWith(github.ref, 'refs/tags/')
        uses: softprops/action-gh-release@v2
        with:
          prerelease: true
          files: |
            ${{ github.workspace }}/devtools-${{ github.ref_name }}.zip
```

### Checklist
- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] My code follows the project's coding standards
- [x] I have added/updated tests as needed
- [x] All tests pass locally